### PR TITLE
fix: Upgrade HTTP3 vertion to fix synchronization with one drive - EXO-69480

### DIFF
--- a/cloud-drive-connectors-services/onedrive/pom.xml
+++ b/cloud-drive-connectors-services/onedrive/pom.xml
@@ -46,6 +46,12 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+      <scope>compile</scope>
+      <type>jar</type>
+    </dependency>
 
     <!-- Cloud Drive add-on -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
     <!-- One Drive API -->
     <!-- **************************************** -->
     <com.microsoft.graph.version>1.7.1</com.microsoft.graph.version>
+    <com.squareup.okhttp3.version>4.4.1</com.squareup.okhttp3.version>
     <!-- Sonar properties -->
     <sonar.organization>exoplatform</sonar.organization>
   </properties>
@@ -127,6 +128,11 @@
         <groupId>com.microsoft.graph</groupId>
         <artifactId>microsoft-graph</artifactId>
         <version>${com.microsoft.graph.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>okhttp</artifactId>
+        <version>${com.squareup.okhttp3.version}</version>
       </dependency>
 
     </dependencies>


### PR DESCRIPTION
Before this change, a defClassNotfound exception for Http3 and Okio classes when trying to connect to one drive (Http3 and Okio are external libraries shaded into cloud drive connectors services) After this change, Upgrading the version of http3 fixes the synchronization with one drive